### PR TITLE
Make viewer instance public

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -486,6 +486,12 @@
       "integrity": "sha512-UBYHWph6P3tutkbXpW6XYg9ZPbTKjw/YC2hGG1/GEvWwTbvezBUv3h+mmUFw79T3RFPnmedpiXdOBbXX+4l0jg==",
       "dev": true
     },
+    "@types/viewerjs": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@types/viewerjs/-/viewerjs-0.7.2.tgz",
+      "integrity": "sha512-KYQo07dOOQ54vEIpQN19tEcDXLtEi/mNWCB7oFLzAznmvJ9Py7x6Ylp4qLexwTp4KJoM3KF6/D2bQEVyNvS7ug==",
+      "dev": true
+    },
     "@webassemblyjs/ast": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.4.3.tgz",
@@ -10924,6 +10930,11 @@
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
       }
+    },
+    "viewerjs": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/viewerjs/-/viewerjs-1.3.2.tgz",
+      "integrity": "sha512-P9Ac9H+GJ1jE9B5x8foRYm/xZvpWFR6L4GC9mr6181P9amOzQPDkplQrFj8l7mdnv8EyH2dO8XJJfoylir316A=="
     },
     "vlq": {
       "version": "0.2.3",

--- a/projects/ngx-viewer/src/lib/ngx-viewer.directive.ts
+++ b/projects/ngx-viewer/src/lib/ngx-viewer.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, NgModule, OnDestroy, AfterViewInit, Input, Output, EventEmitter } from '@angular/core';
+﻿import { Directive, ElementRef, NgModule, OnDestroy, AfterViewInit, Input, Output, EventEmitter } from '@angular/core';
 
 import * as ViewerLibrary from 'viewerjs';
 const Viewer = ViewerLibrary.default;
@@ -19,7 +19,8 @@ export class NgxViewerDirective implements AfterViewInit, OnDestroy {
   @Output() private viewerZoom: EventEmitter<Event> = new EventEmitter<Event>();
   @Output() private viewerZoomed: EventEmitter<Event> = new EventEmitter<Event>();
 
-  private viewer: any;
+  instance: Viewer;
+
   private nativeElement: HTMLElement;
 
   constructor(private elementRef: ElementRef) {
@@ -31,11 +32,11 @@ export class NgxViewerDirective implements AfterViewInit, OnDestroy {
   }
 
   private initViewer(): void {
-    if (this.viewer) {
-      this.viewer.destroy();
+    if (this.instance) {
+      this.instance.destroy();
     }
 
-    this.viewer = new Viewer(this.nativeElement, {
+    this.instance = new Viewer(this.nativeElement, {
       // Transitions currently break the Viewer when running optimizations during ng build (i.e in prod mode)
       // TODO: Find a fix for this so we don't have to force disable transitions
       transition: false,
@@ -54,8 +55,8 @@ export class NgxViewerDirective implements AfterViewInit, OnDestroy {
   }
 
   public ngOnDestroy(): void {
-    if (this.viewer) {
-      this.viewer.destroy();
+    if (this.instance) {
+      this.instance.destroy();
     }
   }
 }


### PR DESCRIPTION
This PR renames the private `viewer` property to `instance` and makes it public, so that one can get a hold of the directive via `@ViewChild` and call the viewer's available methods to interact with it. 

E.g.

```
<div ngxViewer class="hidden">
    <img *ngFor="let image of (images$ | async)" [src]="image" />
</div>

@ViewChild(NgxViewerDirective) imageViewer: NgxViewerDirective;
images$: Observable<string[]>;

// Update viewer after the images$ Observable emits new images
this.imageViewer.instance.update();

// Programmatically open the viewer at a specific index
this.imageViewer.instance.view(2);
```